### PR TITLE
Add period after "Find Jobs" title

### DIFF
--- a/src/components/JobList/JobList.js
+++ b/src/components/JobList/JobList.js
@@ -84,7 +84,7 @@ class JobList extends Component {
     return (
       <article id="gym-microservice-find-work" className="job-list">
         <header>
-          <h2>Find Work</h2>
+          <h2>Find Work.</h2>
           <p>Find work that best fits your skills, in your area.</p>
         </header>
         <form method="get" id="find-work-search">


### PR DESCRIPTION
# What this PR Does
- this is a test of the heroku pipeline
- it adds a `.` after "Find Work" in the title of the job list