### PR TITLE
Return a default value if no marketId is provided

### DIFF
--- a/src/util/util.js
+++ b/src/util/util.js
@@ -33,8 +33,13 @@ export const getMarketFromLatLong = (position) => {
  */
 export const getMarketFromId = (marketId) => {
   if (!marketId) return undefined;
+  if (Number.isNaN(marketId)) return undefined;
 
-  return MARKETS[marketId];
+  let market = MARKETS[marketId];
+  // default to boston if we do not have a valid marketId supplied
+  if (!market) market = MARKETS['10'];
+
+  return market;
 };
 
 export const fetchJobsForMarket = async (marketId, minorSegments = []) => {


### PR DESCRIPTION
# What this PR does
if someone tries to access the microservice from a URL with a bad/malformed marketID, we now default to boston rather than crashing.
