### PR TITLE
Fallback logic added to API call

### DIFF
--- a/src/components/JobTable/JobTable.css
+++ b/src/components/JobTable/JobTable.css
@@ -464,9 +464,6 @@ p.job-market {
     top: 0;
     bottom: 0;
     right: .625em;
-    height: 1.6em;
-    margin-top: auto;
-    margin-bottom: auto;
   }
 
   .job-link a {

--- a/src/components/JobsView/JobsView.js
+++ b/src/components/JobsView/JobsView.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import qs from 'query-string';
 
 import {
-  fetchJobsForMarket,
+  fetchJobs,
   getMarketFromURLParams,
 } from '../../util/util';
 
@@ -78,7 +78,7 @@ class JobsView extends Component {
         this.setState({ market: marketOverride });
       }
 
-      const jobs = await fetchJobsForMarket(marketId, options);
+      const jobs = await fetchJobs(marketId, options);
       this.handleJobsLoaded(jobs);
     } catch (e) {
       console.log('error', e.message || e);

--- a/src/util/jobApi.js
+++ b/src/util/jobApi.js
@@ -2,7 +2,7 @@
 
 import fetch from 'isomorphic-fetch';
 
-export const loadJobsForMarket = (
+export const loadJobs = (
   marketId,
   options = {},
 ) => new Promise((res /* , reject */) => {

--- a/src/util/jobApi.js
+++ b/src/util/jobApi.js
@@ -2,16 +2,19 @@
 
 import fetch from 'isomorphic-fetch';
 
-export const loadJobs = (
+export const loadJobs = async (
   marketId,
   options = {},
-) => new Promise((res /* , reject */) => {
+) => {
   const {
     majorSegment,
     minorSegment,
     limit,
     page,
   } = options;
+
+  let marketQuery = '';
+  if (marketId) marketQuery = `%20+AquentJob.locationId:${marketId}`;
 
   let minorSegmentQuery = '';
   if (minorSegment) minorSegmentQuery = `%20+AquentJob.minorSpecialty1:${minorSegment}`;
@@ -22,22 +25,61 @@ export const loadJobs = (
   let pageQuery = '';
   if (page) pageQuery = `/offset/${page}`;
 
-  const apiUrl = `https://aquent.com/api/content/render/false/type/json/query/+contentType:AquentJob%20+AquentJob.isPosted:true%20+languageId:1%20+deleted:false%20+working:true%20+AquentJob.locationId:${marketId}${minorSegmentQuery}/orderby/AquentJob.postedDate%20desc${limitQuery}${pageQuery}`;
+  const urlBase = 'https://aquent.com/api/content/render/false/type/json/query/+contentType:AquentJob%20+AquentJob.isPosted:true%20+languageId:1%20+deleted:false%20+working:true';
+  const urlPageLimitSuffix = `/orderby/AquentJob.postedDate%20desc${limitQuery}${pageQuery}`;
 
-  fetch(
-    apiUrl,
-    {
-      contentType: 'application/json',
-      dataType: 'jsonp',
-    },
-  ).then((response) => {
+  // attempt 1: include everything.  Market, major/minor segment
+  let apiUrl = `${urlBase}${marketQuery}${minorSegmentQuery}${urlPageLimitSuffix}`;
+  let jobs = await jobsApiCall(apiUrl);
+
+  if (jobs.length <= 0) {
+    if (minorSegmentQuery.length > 0) {
+      // we got no jobs when we provided everything, let's try without minor segment
+      apiUrl = `${urlBase}${marketQuery}${urlPageLimitSuffix}`;
+      jobs = await jobsApiCall(apiUrl);
+
+      if (jobs.length <= 0) {
+        // we got no jobs for this market at all, so let's try _any jobs_ for this minor segment
+        apiUrl = `${urlBase}${minorSegmentQuery}${urlPageLimitSuffix}`;
+        jobs = await jobsApiCall(apiUrl);
+      }
+
+      if (jobs.length <= 0) {
+        // we got no jobs for this minor segment, and no jobs for this specific market, so let's
+        // query for _any jobs anywhere_ and return that.
+        apiUrl = `${urlBase}${urlPageLimitSuffix}`;
+        jobs = await jobsApiCall(apiUrl);
+      }
+    } else {
+      // we got no jobs on the first try (with just market), but were never provided a minor segment
+      // to begin with.  We will query for _any jobs anywhere_ and return that.
+      apiUrl = `${urlBase}${urlPageLimitSuffix}`;
+      jobs = await jobsApiCall(apiUrl);
+    }
+  }
+
+  return jobs;
+};
+
+
+const jobsApiCall = async (queryUrl) => {
+  try {
+    const response = await fetch(
+      queryUrl,
+      {
+        contentType: 'application/json',
+        dataType: 'jsonp',
+      },
+    );
     if (response.status <= 200) {
-      return response.text();
+      const body = await response.text();
+      const jobs = JSON.parse(body).contentlets;
+      return jobs;
     }
     console.error('an error has occurred.');
     return null;
-  }).then((body) => {
-    const jobs = JSON.parse(body).contentlets;
-    res(jobs);
-  });
-});
+  } catch (err) {
+    console.error('Error retrieving jobs:', err.message || err);
+    return null;
+  }
+};

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -5,7 +5,7 @@ import {
   DEFAULT_MARKET,
   MARKETS,
 } from './constants';
-import { loadJobsForMarket } from './jobApi';
+import { loadJobs } from './jobApi';
 
 export const getMarketFromURLParams = (
   marketId,
@@ -65,7 +65,7 @@ export const getMarketFromId = (marketId) => {
   return market;
 };
 
-export const fetchJobsForMarket = async (marketId, options) => {
+export const fetchJobs = async (marketId, options) => {
   // make sure a marketId was supplied
   if (!marketId) return null;
 
@@ -74,7 +74,7 @@ export const fetchJobsForMarket = async (marketId, options) => {
 
   // go call the API for that market
   try {
-    return await loadJobsForMarket(marketId, options);
+    return await loadJobs(marketId, options);
   } catch (e) {
     console.error(e);
     return null;


### PR DESCRIPTION
# What this is
Per discussion with @andrewpmiller, this is the logic implemented in the API call for jobs now:

```
if market and segment are provided, try to find jobs that fit that
  if that fails, drop market, and look for any jobs in that segment (this is likely to work for UX, for example)
    if that fails, drop segment, and look for jobs in that market (_this_ is the likely worst case)
      if that fails, just show any ol' job that comes back (this should never happen unless it's a seriously dead market)
```

# To test
1. Look for UX jobs in Boston - that'll work just fine, since there are UX jobs there currently
1. look for UX jobs in Charlotte - there are none currently here, so it will fall back to _any_ jobs in Charlotte
1. look for UX jobs in Fukuoka - there are _no_ jobs there currently, so it'll first try for UX jobs, than any jobs in Fukuoka, then any UX jobs anywhere (which returns results).  If that failed it would have fallen back to any jobs anywhere
