### PR TITLE
Accept a comma delimited list of minor segments in jobs microservice URL

### DIFF
--- a/src/components/JobsView/JobsView.js
+++ b/src/components/JobsView/JobsView.js
@@ -37,22 +37,22 @@ class JobsView extends Component {
     const parsed = qs.parse(location.search);
 
     const {
-      minorSegment,
+      cwid,
     } = parsed;
 
-    // split minorSegment string into an array of integers
+    // split cloudwallid string (cwid) into an array of integers
     // which we will use to query for multiple minor segments
-    const minorSegments = (
-      typeof minorSegment === 'string'
-      && minorSegment.length > 0
-      && minorSegment.split(',')
+    const cwids = (
+      typeof cwid === 'string'
+      && cwid.length > 0
+      && cwid.split(',')
     ) || null;
 
     this.state = {
       initialMarket: market,
       loading: true,
       options: {
-        minorSegments,
+        cwids,
       },
       market,
       jobs: {},

--- a/src/components/JobsView/JobsView.js
+++ b/src/components/JobsView/JobsView.js
@@ -38,15 +38,21 @@ class JobsView extends Component {
 
     const {
       minorSegment,
-      majorSegment,
     } = parsed;
+
+    // split minorSegment string into an array of integers
+    // which we will use to query for multiple minor segments
+    const minorSegments = (
+      typeof minorSegment === 'string'
+      && minorSegment.length > 0
+      && minorSegment.split(',')
+    ) || null;
 
     this.state = {
       initialMarket: market,
       loading: true,
       options: {
-        minorSegment,
-        majorSegment,
+        minorSegments,
       },
       market,
       jobs: {},

--- a/src/util/jobApi.js
+++ b/src/util/jobApi.js
@@ -46,25 +46,26 @@ export const loadJobs = async (
 
   if (jobs.length <= 0) {
     if (minorSegmentQuery.length > 0) {
-      // we got no jobs when we provided everything, let's try without minor segment
-      apiUrl = `${urlBase}${marketQuery}${urlPageLimitSuffix}`;
+      // we got no jobs for this market and minor segment(s) combination,
+      // so let's try _any jobs_ for the given minor segments
+      apiUrl = `${urlBase}${minorSegmentQuery}${urlPageLimitSuffix}`;
       jobs = await jobsApiCall(apiUrl);
 
       if (jobs.length <= 0) {
-        // we got no jobs for this market at all, so let's try _any jobs_ for this minor segment
-        apiUrl = `${urlBase}${minorSegmentQuery}${urlPageLimitSuffix}`;
+        // we got no jobs for this minor segment, let's try any jobs for this market at all
+        apiUrl = `${urlBase}${marketQuery}${urlPageLimitSuffix}`;
         jobs = await jobsApiCall(apiUrl);
       }
 
       if (jobs.length <= 0) {
-        // we got no jobs for this minor segment, and no jobs for this specific market, so let's
+        // we got no jobs for this set of minor segments,
+        // and no jobs for this specific market, so let's
         // query for _any jobs anywhere_ and return that.
         apiUrl = `${urlBase}${urlPageLimitSuffix}`;
         jobs = await jobsApiCall(apiUrl);
       }
     } else {
-      // we got no jobs on the first try (with just market), but were never provided a minor segment
-      // to begin with.  We will query for _any jobs anywhere_ and return that.
+      // Final fallback - query for _any jobs anywhere_ and return that.
       apiUrl = `${urlBase}${urlPageLimitSuffix}`;
       jobs = await jobsApiCall(apiUrl);
     }

--- a/src/util/jobApi.js
+++ b/src/util/jobApi.js
@@ -7,7 +7,7 @@ export const loadJobs = async (
   options = {},
 ) => {
   const {
-    minorSegments, // an array of minor segments that we're searching for
+    cwids, // an array of minor segments that we're searching for
     limit,
     page,
   } = options;
@@ -17,14 +17,14 @@ export const loadJobs = async (
 
   let minorSegmentQuery = '';
   if (
-    Array.isArray(minorSegments)
-    && minorSegments.length > 0
+    Array.isArray(cwids)
+    && cwids.length > 0
   ) {
     // to search for a list of minor segments, we need to provide it to the ODATA api in
     // the following format:
     // (ID1%20ID2%20)
     // basically, this is a list of IDs, separated by %20, and wrapped in Parenthesis
-    const minorSegmentList = minorSegments.reduce(
+    const minorSegmentList = cwids.reduce(
       (accumulator, segment) => `${accumulator}%20${segment}`,
     );
 


### PR DESCRIPTION
# What this PR does
- you can now supply one or many minorSegments to query for by supplying this microservice with a `?minorSegment` URL parameter.  To query for a single minor segment, use `?minorSegment=40`, and to query for multiple, separate markets with a comma: `?minorSegment=40,100,95`
- Removes all logic for `majorSegment`.  This is no longer used.

# Question
- It seems like we have some choices to make as to the business logic used for fallbacks when minor segment is provided.  Should we fall back to [all jobs in the given minor segment], or [all jobs in this market, regardless of minor segment] first?