### PR TITLE
title style fix

### DIFF
--- a/src/components/JobList/JobList.css
+++ b/src/components/JobList/JobList.css
@@ -38,5 +38,5 @@
 
 .job-list,
 .job-list h1 {
-  color: #ebebeb;
+  color: inherit;
 }


### PR DESCRIPTION
adds an `inherit` color rule to make the header for the job module a little more chameleon-y