### PR TITLE
Revert "title style fix"

### DIFF
--- a/src/components/JobList/JobList.css
+++ b/src/components/JobList/JobList.css
@@ -38,5 +38,5 @@
 
 .job-list,
 .job-list h1 {
-  color: inherit;
+  color: #ebebeb;
 }


### PR DESCRIPTION
Reverts gymnasium/jobs-microservice#40

This wasn't a perfect fix.  `inherit` causes the iframe to inherit from _its_ version of bootstrap, not the styles on the parent page, ufortunately.  I'm leaving it as it was so that the home page looks good.  `/courses` looks whack for now 😞 